### PR TITLE
PE-5053 Fix version output for implicit get

### DIFF
--- a/bin/in
+++ b/bin/in
@@ -20,8 +20,11 @@ if [[ -n "$NAMESPACE_FILE" ]]; then
     fi
 fi
 
+VERSION=$(jq -r '.version' < $payload)
+echo "Version: ${VERSION}"
+
 if [[ -z "$NAMESPACE" ]]; then
-    result=""
+    result="$(jq -n "{version:{name:\"none\"}}")"
 else
     export KUBECTL
 


### PR DESCRIPTION
Concourse 4.2.1 UI is breaking due to a `null` version value produced by
 the implicit `get` after `put`ting

Initially returning a `"name": "none"` version, while also adding
 debugging output for the version being passed to the resource, which
 will come from either the `check`, or the `put`