### PR TITLE
Exclude "kubernetes.io/" and "k8s.io/" annotations from output.

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -18,8 +18,8 @@ else
     data="$(mktemp "k8s-resource-data.XXXXXX")"
     $KUBECTL get -o json "$RESOURCE" > "$data" || true # if there are errors or namespace missing, return empty.
 
-    ANNOTATIONS=$(jq -r '.metadata.annotations | to_entries? | map([.key, .value]|join("=")) | join(", ")' < "$data" | tr -d \" )
-    LABELS=$(jq -r '.metadata.labels | to_entries? | map([.key, .value]|join("=")) | join(", ")' < "$data" | tr -d \")
+    ANNOTATIONS=$(jq -r "${GET_ANNOTATIONS}" < "$data" | tr -d \" )
+    LABELS=$(jq -r "${GET_LABELS}" < "$data" | tr -d \")
 
     result=$(jq -n "[{name:\"$NAMESPACE\",annotations:\"$ANNOTATIONS\", labels:\"$LABELS\"}]")
 fi

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -6,13 +6,20 @@ cat > "$payload" <&0
 export payload
 
 DEBUG=$(jq -r .source.debug < "$payload")
-[[ "$DEBUG" == "true" ]] && { 
+[[ "$DEBUG" == "true" ]] && {
     echo "Enabling debug mode.";
     export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
     set -x;
 }
 
 cd "$1" || exit
+
+# shellcheck disable=SC2089
+GET_ANNOTATIONS='.metadata.annotations | with_entries(select(.key|test("kubernetes.io/")|not)) | with_entries(select(.key|test("k8s.io/")|not)) | to_entries? | map([.key, .value]|join("=")) | join(", ")'
+# shellcheck disable=SC2089
+GET_LABELS='.metadata.labels | to_entries? | map([.key, .value]|join("=")) | join(", ")'
+# shellcheck disable=SC2090
+export GET_ANNOTATIONS GET_LABELS
 
 mkdir -p /root/.kube
 

--- a/bin/in
+++ b/bin/in
@@ -7,7 +7,7 @@ exec 1>&2 # send normal stdout to stderr for logging
 # shellcheck source=bin/common.sh
 source "$( dirname "$( readlink -f "$0" )")"/common.sh
 
-# get kube resource id 
+# get kube resource id
 NAMESPACE=$(jq -r ".params.namespace // \"$NAMESPACE\"" < "$payload")
 
 NAMESPACE_FILE=$(jq -r ".params.namespace_file // \"\"" < "$payload")
@@ -32,8 +32,8 @@ else
     data="$(mktemp "k8s-resource-data.XXXXXX")"
     $KUBECTL get -o json "$RESOURCE" > "$data" || true # if there are errors or namespace missing, return empty.
 
-    ANNOTATIONS=$(jq -r '.metadata.annotations | to_entries? | map([.key, .value]|join("=")) | join(", ")' < "$data" | tr -d \")
-    LABELS=$(jq -r '.metadata.labels | to_entries? | map([.key, .value]|join("=")) | join(", ")' < "$data" | tr -d \")
+    ANNOTATIONS=$(jq -r "$GET_ANNOTATIONS" < "$data" | tr -d \")
+    LABELS=$(jq -r "$GET_LABELS" < "$data" | tr -d \")
 
     result="$(jq -n "{version:{name:\"$NAMESPACE\",annotations:\"$ANNOTATIONS\",labels:\"$LABELS\"}}")"
 fi

--- a/bin/out
+++ b/bin/out
@@ -61,8 +61,8 @@ fi
 
 data="$(mktemp "k8s-resource-data.XXXXXX")"
 $KUBECTL get -o json "namespace/$NAMESPACE" | tee "$data" || true # if there are errors or namespace missing, return empty.
-OUT_ANNOTATIONS=$(jq -r '.metadata.annotations | to_entries? | map([.key, .value]|join("=")) | join(", ")' < "$data" | tr -d \")
-OUT_LABELS=$(jq -r '.metadata.labels | to_entries? | map([.key, .value]|join("=")) | join(", ")' < "$data" | tr -d \")
+OUT_ANNOTATIONS=$(jq -r "$GET_ANNOTATIONS" < "$data" | tr -d \")
+OUT_LABELS=$(jq -r "$GET_LABELS" < "$data" | tr -d \")
 
 result="$(jq -n "{version:{name:\"$NAMESPACE\",annotations:\"$OUT_ANNOTATIONS\",labels:\"$OUT_LABELS\"}}")"
 


### PR DESCRIPTION
This was primarily done to not display 'kubectl.kubernetes.io/last-applied-configuration'.