### PR TITLE
Strip kubectl, update versions of alpine.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
-FROM hadolint/hadolint:v1.14.0 AS hadolint
-FROM koalaman/shellcheck:v0.5.0 AS shellcheck
-FROM alpine:3.8 as build
+FROM hadolint/hadolint:v1.16.3 AS hadolint
+FROM koalaman/shellcheck:v0.6.0 AS shellcheck
+FROM alpine:3.9 as build
 
 WORKDIR /tmp/build
 
-ENV KUBE_VERSION="1.11.4"
+ENV KUBE_VERSION="1.11.10"
 ENV kubectlURL https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
 
 # hadolint ignore=DL3018
-RUN apk --no-cache --quiet add jq curl; \
+RUN apk --no-cache --quiet add jq curl upx; \
     curl -L -s -o /usr/local/bin/kubectl \
         ${kubectlURL} && \
-    chmod +x /usr/local/bin/kubectl
+    chmod +x /usr/local/bin/kubectl && \
+    upx --brute /usr/local/bin/kubectl
 
 # Lint, test
 COPY . .
@@ -22,8 +23,8 @@ RUN /usr/local/bin/hadolint ./Dockerfile
 
 RUN /usr/local/bin/shellcheck --format=gcc ./bin/*
 
-FROM alpine:3.8
-RUN apk --no-cache --quiet add jq=1.6_rc1-r1 bash=4.4.19-r1
+FROM alpine:3.9
+RUN apk --no-cache --quiet add jq~=1.6 bash~=4.4
 COPY --from=build /usr/local/bin/kubectl /usr/local/bin/kubectl
 
 COPY bin/* /opt/resource/


### PR DESCRIPTION
Stripping kubectl brings the image size from ~65MB to 20MB.